### PR TITLE
external-secret prefix kubernetes > application

### DIFF
--- a/templates/kubernetes/overlays/production/external-secret.yml
+++ b/templates/kubernetes/overlays/production/external-secret.yml
@@ -8,4 +8,4 @@ metadata:
 spec:
   backendType: secretsManager
   dataFrom:
-  - <% .Name %>/kubernetes/prod/<% .Name %>
+  - <% .Name %>/application/prod/<% .Name %>

--- a/templates/kubernetes/overlays/staging/external-secret.yml
+++ b/templates/kubernetes/overlays/staging/external-secret.yml
@@ -8,4 +8,4 @@ metadata:
 spec:
   backendType: secretsManager
   dataFrom:
-  - <% .Name %>/kubernetes/stage/<% .Name %>
+  - <% .Name %>/application/stage/<% .Name %>

--- a/zero-module.yml
+++ b/zero-module.yml
@@ -1,7 +1,7 @@
 name: zero-backend-go
 description: 'Zero module for a backend service in Go running in Kubernetes'
 author: 'Commit'
-zeroVersion: '>= 0.1.1'
+zeroVersion: '>= 0.2.1'
 commands:
   check: sh scripts/check.sh
 


### PR DESCRIPTION
update to reflect infra changes, 
In secret manager we create secret for application to reference,
now this is used for both serverless and kubernetes so application is more
appropriate